### PR TITLE
Tried to update your project to Akka 1.0

### DIFF
--- a/project/build/AkkaRedisClient.scala
+++ b/project/build/AkkaRedisClient.scala
@@ -1,13 +1,12 @@
 import sbt._
 import sbt.CompileOrder._
 
-class FyrieRedisProject(info: ProjectInfo) extends DefaultProject(info) with AkkaBaseProject with Boilerplate
+class FyrieRedisProject(info: ProjectInfo) extends DefaultProject(info) with AkkaProject with Boilerplate
 {
   override def compileOptions = Optimize :: Unchecked :: super.compileOptions.toList /* ++ Seq( "-verbose", "-Ydebug" ).map(CompileOption(_)) */
   override def mainSourceRoots = super.mainSourceRoots +++ srcManagedScala
   override def compileAction = super.compileAction dependsOn(generateSortTuple)
 
-  val akkaActor = "se.scalablesolutions.akka" % "akka-actor_2.8.0"  % "1.0-M1"
   val specs = "org.scala-tools.testing" %% "specs" % "1.6.6" % "test"
   val scalatest = "org.scalatest" % "scalatest" % "1.2" % "test"
   val junit = "junit" % "junit" % "4.8.1" % "test"
@@ -25,5 +24,4 @@ class FyrieRedisProject(info: ProjectInfo) extends DefaultProject(info) with Akk
   val fyrieReleases           = "Fyrie releases" at "http://repo.fyrie.net/releases"
   val fyrieSnapshots          = "Fyrie snapshots" at "http://repo.fyrie.net/snapshots"
   val scalaToolsSnapshots     = ScalaToolsSnapshots
-  val akkaModuleConfig        = ModuleConfiguration("se.scalablesolutions.akka", AkkaRepositories.AkkaRepo)
 }

--- a/project/build/Boilerplate.scala
+++ b/project/build/Boilerplate.scala
@@ -66,7 +66,7 @@ trait Boilerplate {
               "package handlers {\n\n" +
               "import serialization.Parse\n" +
               "import utils._\n" +
-              "import se.scalablesolutions.akka.dispatch.{Future, CompletableFuture, DefaultCompletableFuture}\n" +
+              "import akka.dispatch.{Future, CompletableFuture, DefaultCompletableFuture}\n" +
               tupleHandlers.mkString("\n") +
               "}\n\n" +
               "package commands {\n\n" +

--- a/project/plugins/Plugins.scala
+++ b/project/plugins/Plugins.scala
@@ -1,5 +1,5 @@
 import sbt._
  
 class Plugins(info: ProjectInfo) extends PluginDefinition(info) {
-  val akkaPlugin = "se.scalablesolutions.akka" % "akka-sbt-plugin" % "1.0-SNAPSHOT"
+  val akkaPlugin = "se.scalablesolutions.akka" % "akka-sbt-plugin" % "1.0"
 }

--- a/src/main/scala/Actors.scala
+++ b/src/main/scala/Actors.scala
@@ -6,11 +6,11 @@ import messages._
 import handlers._
 import RedisType._
 
-import se.scalablesolutions.akka.actor.{ Actor, ActorRef }
+import akka.actor.{ Actor, ActorRef }
 import Actor.{ actorOf }
-import se.scalablesolutions.akka.config.Config._
+import akka.config.Config._
 
-import se.scalablesolutions.akka.dispatch._
+import akka.dispatch._
 
 import org.fusesource.hawtdispatch._
 import org.fusesource.hawtdispatch.ScalaDispatch._

--- a/src/main/scala/Handlers.scala
+++ b/src/main/scala/Handlers.scala
@@ -5,7 +5,7 @@ import serialization.{ Parse }
 import Parse.Implicits._
 import utils._
 
-import se.scalablesolutions.akka.dispatch.{Future, CompletableFuture, DefaultCompletableFuture}
+import akka.dispatch.{Future, CompletableFuture, DefaultCompletableFuture}
 
 abstract class Handler[A](implicit val manifest: Manifest[A]) {
   def verify(in: String, expect: String): Unit =

--- a/src/main/scala/RedisClient.scala
+++ b/src/main/scala/RedisClient.scala
@@ -5,11 +5,11 @@ import actors._
 import messages.{Request}
 import handlers._
 
-import se.scalablesolutions.akka.dispatch.{Future, FutureTimeoutException}
-import se.scalablesolutions.akka.actor.{Actor,ActorRef}
+import akka.dispatch.{Future, FutureTimeoutException}
+import akka.actor.{Actor,ActorRef}
 import Actor.{actorOf}
-import se.scalablesolutions.akka.dispatch._
-import se.scalablesolutions.akka.config.Config._
+import akka.dispatch._
+import akka.config.Config._
 
 class RedisClient(host: String = config.getString("fyrie-redis.host", "localhost"),
                   port: Int = config.getInt("fyrie-redis.port", 6379)) {

--- a/src/main/scala/Responder.scala
+++ b/src/main/scala/Responder.scala
@@ -3,8 +3,8 @@ package net.fyrie.redis
 import handlers._
 import utils._
 import RedisType._
-import se.scalablesolutions.akka.actor.{ Actor, ActorRef }
-import se.scalablesolutions.akka.dispatch._
+import akka.actor.{ Actor, ActorRef }
+import akka.dispatch._
 
 import org.fusesource.hawtdispatch.ScalaDispatch._
 

--- a/src/main/scala/Result.scala
+++ b/src/main/scala/Result.scala
@@ -74,7 +74,7 @@ final case class Error[A](exception: Throwable)(implicit val manifest: Manifest[
   override def toString = "Error(" + exception.toString + ")"
 }
 
-class ResponseFuture[A](timeout: Long = 0)(implicit val manifest: Manifest[A]) extends se.scalablesolutions.akka.dispatch.DefaultCompletableFuture[A](timeout) {
+class ResponseFuture[A](timeout: Long = 0)(implicit val manifest: Manifest[A]) extends akka.dispatch.DefaultCompletableFuture[A](timeout) {
   def toResponse: Response[A] =
     this.await.result.map(Result(_)(manifest)).orElse(this.exception.map(Error(_)(manifest))).getOrElse(Error(error("ERROR")))
 }

--- a/src/main/scala/collections/RedisList.scala
+++ b/src/main/scala/collections/RedisList.scala
@@ -5,7 +5,7 @@ import serialization._
 
 import scala.collection.mutable.{IndexedSeq}
 
-import se.scalablesolutions.akka.dispatch.{Future}
+import akka.dispatch.{Future}
 
 object RedisList {
   def apply[A](name: String)(implicit conn: RedisClient, format: Format, parser: Parse[A], m: Manifest[A]): RedisList[A] =

--- a/src/main/scala/collections/RedisSet.scala
+++ b/src/main/scala/collections/RedisSet.scala
@@ -3,7 +3,7 @@ package collection
 
 import serialization._
 
-import se.scalablesolutions.akka.dispatch.{Future}
+import akka.dispatch.{Future}
 
 import scala.collection.mutable
 

--- a/src/main/scala/collections/RedisVar.scala
+++ b/src/main/scala/collections/RedisVar.scala
@@ -3,7 +3,7 @@ package collection
 
 import serialization._
 
-import se.scalablesolutions.akka.dispatch.{Future}
+import akka.dispatch.{Future}
 
 object RedisVar {
   def apply[A](name: String, default: Option[A] = None)(implicit conn: RedisClient, format: Format, parser: Parse[A], m: Manifest[A]): RedisVar[A] =

--- a/src/test/resources/akka.conf
+++ b/src/test/resources/akka.conf
@@ -1,5 +1,5 @@
 akka {
-  version = "1.0-M1"
+  version = "1.0"
 }
 
 fyrie-redis {

--- a/src/test/scala/ActorResponderSpec.scala
+++ b/src/test/scala/ActorResponderSpec.scala
@@ -6,9 +6,9 @@ import handlers._
 import org.specs._
 import specification.Context
 
-import se.scalablesolutions.akka.actor._
+import akka.actor._
 import Actor._
-import se.scalablesolutions.akka.dispatch._
+import akka.dispatch._
 
 class ActorResponderSpec extends Specification {
   var r: RedisClient = _

--- a/src/test/scala/ActorResponderSpec.scala
+++ b/src/test/scala/ActorResponderSpec.scala
@@ -13,7 +13,7 @@ import akka.dispatch._
 class ActorResponderSpec extends Specification {
   var r: RedisClient = _
 
-  val empty = new Context {
+  val emptyDb = new Context {
     before {
       r = new RedisClient
       r send flushdb
@@ -24,7 +24,7 @@ class ActorResponderSpec extends Specification {
     }
   }
 
-  "sending requests from an actor" ->- empty should {
+  "sending requests from an actor" ->- emptyDb should {
     "return simple requests" in {
       val future = new DefaultCompletableFuture[List[Option[Any]]](5000)
       val actor = actorOf(new MatchingActor(r,

--- a/src/test/scala/ExceptionHandlingSpec.scala
+++ b/src/test/scala/ExceptionHandlingSpec.scala
@@ -8,7 +8,7 @@ import specification.Context
 class ExceptionHandlingSpec extends Specification {
   var r: RedisClient = _
 
-  val empty = new Context {
+  val emptyDb = new Context {
     before {
       r = new RedisClient
       r send flushdb
@@ -19,7 +19,7 @@ class ExceptionHandlingSpec extends Specification {
     }
   }
 
-  "redis exceptions" ->- empty should {
+  "redis exceptions" ->- emptyDb should {
     "recover" in {
       "single commands" in {
         r send set("hello", "world")

--- a/src/test/scala/RedisListSpec.scala
+++ b/src/test/scala/RedisListSpec.scala
@@ -9,7 +9,7 @@ import specification.Context
 class RedisListSpec extends Specification {
   implicit val r = new RedisClient
 
-  val empty = new Context {
+  val emptyDb = new Context {
     before {
       r !! flushdb
     }
@@ -18,7 +18,7 @@ class RedisListSpec extends Specification {
     }
   }
 
-  "size" ->- empty should {
+  "size" ->- emptyDb should {
     "return 0 for empty list" in {
       val list = RedisList[String]("test list 1")
       list must haveSize(0)
@@ -31,7 +31,7 @@ class RedisListSpec extends Specification {
       list must haveSize(3)
     }
   }
-  "slice" ->- empty should {
+  "slice" ->- emptyDb should {
     "return a slice" in {
       val list = RedisList[String]("test list 1")
       "I'm going first" +=: list += ("Hello", "World")
@@ -39,7 +39,7 @@ class RedisListSpec extends Specification {
       list.slice(0,1) must_== Seq("I'm going first", "Hello")
     }
   }
-  "lpop/rpop" ->- empty should {
+  "lpop/rpop" ->- emptyDb should {
     "pop from the list" in {
       val list = RedisList[String]("test list 1")
       list += ("Hello", "World", "test1", "test2", "I'm last")

--- a/src/test/scala/RedisSetSpec.scala
+++ b/src/test/scala/RedisSetSpec.scala
@@ -9,7 +9,7 @@ import specification.Context
 class RedisSetSpec extends Specification {
   implicit val r = new RedisClient
 
-  val empty = new Context {
+  val emptyDb = new Context {
     before {
       r !! flushdb
     }
@@ -18,7 +18,7 @@ class RedisSetSpec extends Specification {
     }
   }
 
-  "size" ->- empty should {
+  "size" ->- emptyDb should {
     "return 0 for empty set" in {
       val set = RedisSet[String]("test set 1")
       set must haveSize(0)
@@ -33,7 +33,7 @@ class RedisSetSpec extends Specification {
       set must haveSize(3)
     }
   }
-  "spop" ->- empty should {
+  "spop" ->- emptyDb should {
     "pop from the set" in {
       val set = RedisSet[String]("test set 1")
       val vs = Set("Hello", "World", "test1", "test2", "I'm last")


### PR DESCRIPTION
Hi Derek,

I tried to upgrade your project to Akka 1.0. Most things went fine but once I got everything to compile tests still fail with timeouts. Obviously, redis server is running and I see that it receives connections from tests. I don't understand what's going on. Could you have a look at those problems?

Here's the stacktrace

```
[info] == net.fyrie.redis.SetOperationsSpec ==
akka.dispatch.FutureTimeoutException
[mac-grek.local_ddefcca0-46b5-11e0-969b-001c42000009]
Futures timed out after [5000] milliseconds
null
at akka.dispatch.DefaultCompletableFuture.await(Future.scala:216)
at net.fyrie.redis.RedisClient.send(RedisClient.scala:43)
at net.fyrie.redis.RedisTestServer$class.beforeAll(TestServer.scala:15)
at net.fyrie.redis.SetOperationsSpec.beforeAll(SetSpec.scala:12)
at org.scalatest.BeforeAndAfterAll$class.beforeAll(BeforeAndAfterAll.scala:150)
at net.fyrie.redis.SetOperationsSpec.beforeAll(SetSpec.scala:12)
at org.scalatest.BeforeAndAfterAll$class.run(BeforeAndAfterAll.scala:211)
at net.fyrie.redis.SetOperationsSpec.run(SetSpec.scala:12)
at org.scalatest.tools.ScalaTestFramework$ScalaTestRunner.run(ScalaTestFramework.scala:40)
```
